### PR TITLE
Make it match the behavior of "Close to the Right"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "close-tabs-to-the-left",
     "displayName": "close tabs to the left",
     "description": "simply adds 'Close to the Left' item to the Title Tab menu",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "ctf0",
     "repository": "https://github.com/ctf0/close-tabs-to-the-left.git",
     "engines": {
@@ -19,19 +19,20 @@
     ],
     "icon": "icon.png",
     "contributes": {
-        "menus": {
-            "editor/context": [
-                {
-                    "command": "workbench.action.closeEditorsToTheLeft",
-                    "group": "5_close"
-                }
-            ],
-            "editor/title/context": [
-                {
-                    "command": "workbench.action.closeEditorsToTheLeft",
-                    "group": "1_close"
-                }
-            ]
-        }
-    }
+		"commands": [
+			{
+				"command": "workbench.action.closeEditorsToTheLeft",
+				"title": "Close to the Left",
+				"enablement": "!activeEditorIsFirstInGroup"
+			}
+		],
+		"menus": {
+			"editor/title/context": [
+				{
+					"command": "workbench.action.closeEditorsToTheLeft",
+					"group": "1_close@29"
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
- Will be disabled on the first tab in a group
- Sits below "Close Others" and above "Close to the Right"
- Displays text "Close to the Left"